### PR TITLE
qrc: requirements: update vulnerable dependencies

### DIFF
--- a/QRC/requirements.txt
+++ b/QRC/requirements.txt
@@ -153,7 +153,7 @@ terminado==0.18.1
 threadpoolctl==3.5.0
 tinycss2==1.3.0
 tomli==2.0.1
-tornado==6.4.1
+tornado~=6.4.2
 traitlets==5.14.3
 types-python-dateutil==2.9.0.20240316
 typing_extensions==4.12.2
@@ -164,6 +164,6 @@ wcwidth==0.2.13
 webcolors==24.6.0
 webencodings==0.5.1
 websocket-client==1.8.0
-Werkzeug==3.0.3
+Werkzeug~=3.0.6
 wrapt==1.16.0
 xyzservices==2024.6.0


### PR DESCRIPTION
Dependabot notified me that both `tornado` and `werkzeug` had vulnerable versions in the `requirements.txt`.

I'm updating them to hopefully still be compatibile but pick up the latest security fixes.

Since this includes a full `pip freeze` instead of the base dependencies this may add extra dependencies.